### PR TITLE
Don't generate tags for unexported fields and support generating multiple files at once

### DIFF
--- a/easytags.go
+++ b/easytags.go
@@ -9,6 +9,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unicode"
@@ -46,8 +47,17 @@ func main() {
 	if len(tagNames) == 0 && *remove == false {
 		tagNames = append(tagNames, defaultTag)
 	}
-
-	GenerateTags(args[0], tagNames)
+	for _, arg := range args {
+		files, err := filepath.Glob(arg)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+			return
+		}
+		for _, f := range files {
+			GenerateTags(f, tagNames)
+		}
+	}
 }
 
 // GenerateTags generates snake case json tags so that you won't need to write them. Can be also extended to xml or sql tags

--- a/easytags.go
+++ b/easytags.go
@@ -129,6 +129,10 @@ func processTags(x *ast.StructType, tagNames []string) {
 		if len(field.Names) == 0 {
 			continue
 		}
+		if !unicode.IsUpper(rune(field.Names[0].String()[0])) {
+			// not exported
+			continue
+		}
 
 		if field.Tag == nil {
 			field.Tag = &ast.BasicLit{}


### PR DESCRIPTION
I used easytags to mass-generate some tags and it worked great! To help my effort, I made these two improvements-- figured I may as well share. Cheers!